### PR TITLE
Add basic exchange connectors for Binance and BingX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # hermes-trading
+
+Prototype trading bot framework.
+
+## Features
+
+- Exchange connector interface.
+- Implementations for **Binance** and **BingX** using [CCXT](https://github.com/ccxt/ccxt).
+
+## Development
+
+Install dependencies and run tests:
+
+```bash
+pip install -e .
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "hermes-trading"
+version = "0.1.0"
+description = "Trading bot framework core"
+requires-python = ">=3.10"
+dependencies = [
+    "ccxt>=4.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/src/hermes_trading/__init__.py
+++ b/src/hermes_trading/__init__.py
@@ -1,0 +1,3 @@
+"""Hermes Trading Bot core package."""
+
+__all__ = ["connectors"]

--- a/src/hermes_trading/connectors/__init__.py
+++ b/src/hermes_trading/connectors/__init__.py
@@ -1,0 +1,11 @@
+"""Exchange connectors for the Hermes Trading Bot."""
+
+from .base import ExchangeConnector
+from .binance import BinanceConnector
+from .bingx import BingXConnector
+
+__all__ = [
+    "ExchangeConnector",
+    "BinanceConnector",
+    "BingXConnector",
+]

--- a/src/hermes_trading/connectors/base.py
+++ b/src/hermes_trading/connectors/base.py
@@ -1,0 +1,18 @@
+"""Abstract base class for exchange connectors."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class ExchangeConnector(ABC):
+    """Defines the common interface for all exchange connectors."""
+
+    @abstractmethod
+    def get_market_price(self, symbol: str) -> float:
+        """Return the latest market price for a trading pair."""
+
+    @abstractmethod
+    def place_order(
+        self, symbol: str, side: str, amount: float, price: float | None = None
+    ) -> Any:
+        """Place an order and return the exchange response."""

--- a/src/hermes_trading/connectors/binance.py
+++ b/src/hermes_trading/connectors/binance.py
@@ -1,0 +1,24 @@
+"""Connector for the Binance exchange using CCXT."""
+
+from __future__ import annotations
+
+import ccxt
+
+from .base import ExchangeConnector
+
+
+class BinanceConnector(ExchangeConnector):
+    """Provides basic market data and order execution for Binance."""
+
+    def __init__(self, api_key: str | None = None, secret: str | None = None):
+        self.client = ccxt.binance({"apiKey": api_key, "secret": secret})
+
+    def get_market_price(self, symbol: str) -> float:
+        ticker = self.client.fetch_ticker(symbol)
+        return ticker["last"]
+
+    def place_order(
+        self, symbol: str, side: str, amount: float, price: float | None = None
+    ) -> dict:
+        order_type = "market" if price is None else "limit"
+        return self.client.create_order(symbol, order_type, side, amount, price)

--- a/src/hermes_trading/connectors/bingx.py
+++ b/src/hermes_trading/connectors/bingx.py
@@ -1,0 +1,24 @@
+"""Connector for the BingX exchange using CCXT."""
+
+from __future__ import annotations
+
+import ccxt
+
+from .base import ExchangeConnector
+
+
+class BingXConnector(ExchangeConnector):
+    """Provides basic market data and order execution for BingX."""
+
+    def __init__(self, api_key: str | None = None, secret: str | None = None):
+        self.client = ccxt.bingx({"apiKey": api_key, "secret": secret})
+
+    def get_market_price(self, symbol: str) -> float:
+        ticker = self.client.fetch_ticker(symbol)
+        return ticker["last"]
+
+    def place_order(
+        self, symbol: str, side: str, amount: float, price: float | None = None
+    ) -> dict:
+        order_type = "market" if price is None else "limit"
+        return self.client.create_order(symbol, order_type, side, amount, price)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,11 @@
+from hermes_trading.connectors import BinanceConnector, BingXConnector
+
+
+def test_binance_connector_instantiates():
+    connector = BinanceConnector()
+    assert connector.client is not None
+
+
+def test_bingx_connector_instantiates():
+    connector = BingXConnector()
+    assert connector.client is not None


### PR DESCRIPTION
## Summary
- add abstract exchange connector interface
- implement Binance and BingX connectors using CCXT
- configure project dependencies and tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ab565b8c908326ae2e37dbaa5b3fb6