### PR TITLE
Add kline API connectors and price action analysis

### DIFF
--- a/scan_month_signals.py
+++ b/scan_month_signals.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Fetch last month's candles and print any price action signals."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from hermes_trading.candles import Candle, CandleBatch
+from hermes_trading.connectors import BinanceConnector
+from hermes_trading.signals import PriceActionSignal
+
+
+def main() -> None:
+    symbol = "BTC/USDT"
+    timeframe = "1h"
+    since = int((datetime.utcnow() - timedelta(days=30)).timestamp() * 1000)
+
+    connector = BinanceConnector()
+    ohlcv = connector.client.fetch_ohlcv(symbol, timeframe=timeframe, since=since)
+    candles = [Candle(ts, o, h, l, c) for ts, o, h, l, c, *_ in ohlcv]
+
+    signal = PriceActionSignal()
+    seen: set[tuple[int, str]] = set()
+
+    for i in range(0, len(candles) - 9):
+        batch = CandleBatch(candles[i : i + 10])
+        for res in signal.evaluate(batch):
+            name, idx = res.split("@")
+            candle = batch.candles[int(idx)]
+            key = (candle.timestamp, name)
+            if key in seen:
+                continue
+            seen.add(key)
+            ts = datetime.fromtimestamp(candle.timestamp / 1000, tz=timezone.utc)
+            print(
+                f"{name} at {ts.isoformat()} - O:{candle.open} H:{candle.high} L:{candle.low} C:{candle.close}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hermes_trading/__init__.py
+++ b/src/hermes_trading/__init__.py
@@ -1,5 +1,5 @@
 """Hermes Trading Bot core package."""
 
-from . import connectors, signals
+from . import connectors, signals, candles
 
-__all__ = ["connectors", "signals"]
+__all__ = ["connectors", "signals", "candles"]

--- a/src/hermes_trading/candles.py
+++ b/src/hermes_trading/candles.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Candle:
+    """Represents a single OHLCV candle."""
+
+    timestamp: int
+    open: float
+    high: float
+    low: float
+    close: float
+
+
+@dataclass
+class CandleBatch:
+    """Container for exactly ten sequential candles."""
+
+    candles: List[Candle]
+
+    def __post_init__(self) -> None:
+        if len(self.candles) != 10:
+            raise ValueError("CandleBatch must contain exactly 10 candles")

--- a/src/hermes_trading/connectors/base.py
+++ b/src/hermes_trading/connectors/base.py
@@ -3,6 +3,8 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
+from ..candles import CandleBatch
+
 
 class ExchangeConnector(ABC):
     """Defines the common interface for all exchange connectors."""
@@ -10,6 +12,12 @@ class ExchangeConnector(ABC):
     @abstractmethod
     def get_market_price(self, symbol: str) -> float:
         """Return the latest market price for a trading pair."""
+
+    @abstractmethod
+    def get_klines(
+        self, symbol: str, interval: str, limit: int = 10
+    ) -> CandleBatch:
+        """Return a batch of ``limit`` candles for ``symbol``."""
 
     @abstractmethod
     def place_order(

--- a/src/hermes_trading/connectors/binance.py
+++ b/src/hermes_trading/connectors/binance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ccxt
 
 from .base import ExchangeConnector
+from ..candles import Candle, CandleBatch
 
 
 class BinanceConnector(ExchangeConnector):
@@ -16,6 +17,16 @@ class BinanceConnector(ExchangeConnector):
     def get_market_price(self, symbol: str) -> float:
         ticker = self.client.fetch_ticker(symbol)
         return ticker["last"]
+
+    def get_klines(
+        self, symbol: str, interval: str, limit: int = 10
+    ) -> CandleBatch:
+        ohlcv = self.client.fetch_ohlcv(symbol, timeframe=interval, limit=limit)
+        candles = [
+            Candle(ts, open_, high, low, close)
+            for ts, open_, high, low, close, *_ in ohlcv
+        ]
+        return CandleBatch(candles)
 
     def place_order(
         self, symbol: str, side: str, amount: float, price: float | None = None

--- a/src/hermes_trading/connectors/bingx.py
+++ b/src/hermes_trading/connectors/bingx.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ccxt
 
 from .base import ExchangeConnector
+from ..candles import Candle, CandleBatch
 
 
 class BingXConnector(ExchangeConnector):
@@ -16,6 +17,16 @@ class BingXConnector(ExchangeConnector):
     def get_market_price(self, symbol: str) -> float:
         ticker = self.client.fetch_ticker(symbol)
         return ticker["last"]
+
+    def get_klines(
+        self, symbol: str, interval: str, limit: int = 10
+    ) -> CandleBatch:
+        ohlcv = self.client.fetch_ohlcv(symbol, timeframe=interval, limit=limit)
+        candles = [
+            Candle(ts, open_, high, low, close)
+            for ts, open_, high, low, close, *_ in ohlcv
+        ]
+        return CandleBatch(candles)
 
     def place_order(
         self, symbol: str, side: str, amount: float, price: float | None = None

--- a/src/hermes_trading/signals/base.py
+++ b/src/hermes_trading/signals/base.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Sequence
 
+from ..candles import CandleBatch
+
 
 class Signal(ABC):
     """Abstract interface for evaluating trading signals."""
 
     @abstractmethod
-    def evaluate(self, prices: Sequence[float]) -> bool:
-        """Return ``True`` if a signal is triggered for the given prices."""
+    def evaluate(self, candles: CandleBatch) -> Sequence[str]:
+        """Return detected signals for the provided candles."""

--- a/src/hermes_trading/signals/price_action.py
+++ b/src/hermes_trading/signals/price_action.py
@@ -3,31 +3,39 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import List
 
+from ..candles import Candle, CandleBatch
 from .base import Signal
 
 
 @dataclass
 class PriceActionSignal(Signal):
-    """Detects price action patterns within a series of prices.
+    """Detects price action patterns within a batch of candles."""
 
-    Parameters
-    ----------
-    pattern:
-        Name of the pattern to evaluate. The actual pattern detection logic
-        is left as a placeholder for future implementation.
-    """
+    def evaluate(self, candles: CandleBatch) -> List[str]:  # type: ignore[override]
+        signals: List[str] = []
+        bars = candles.candles
+        for i, bar in enumerate(bars):
+            if self._is_pin_bar(bar):
+                signals.append(f"pin_bar@{i}")
+            if i > 0 and self._is_bullish_engulfing(bars[i - 1], bar):
+                signals.append(f"bullish_engulfing@{i}")
+        return signals
 
-    pattern: str
+    @staticmethod
+    def _is_bullish_engulfing(prev: Candle, curr: Candle) -> bool:
+        return (
+            prev.close < prev.open
+            and curr.close > curr.open
+            and curr.close > prev.open
+            and curr.open < prev.close
+        )
 
-    def evaluate(self, prices: Sequence[float]) -> bool:  # noqa: D401
-        """Evaluate whether the configured pattern exists in ``prices``.
-
-        Currently this method is a stub and always returns ``False``. Concrete
-        pattern recognition algorithms will be implemented in subsequent
-        iterations of the trading bot.
-        """
-
-        # TODO: Implement pattern recognition based on ``self.pattern``
-        return False
+    @staticmethod
+    def _is_pin_bar(c: Candle) -> bool:
+        body = abs(c.close - c.open)
+        rng = c.high - c.low
+        tail = min(c.open, c.close) - c.low
+        head = c.high - max(c.open, c.close)
+        return body < rng * 0.3 and tail > head * 2

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,4 +1,5 @@
 from hermes_trading.connectors import BinanceConnector, BingXConnector
+from unittest.mock import patch
 
 
 def test_binance_connector_instantiates():
@@ -6,6 +7,22 @@ def test_binance_connector_instantiates():
     assert connector.client is not None
 
 
+def test_binance_get_klines_returns_ten_candles():
+    connector = BinanceConnector()
+    dummy = [[i, 1, 2, 0, 1, 0] for i in range(10)]
+    with patch.object(connector.client, "fetch_ohlcv", return_value=dummy):
+        batch = connector.get_klines("BTC/USDT", "1m")
+    assert len(batch.candles) == 10
+
+
 def test_bingx_connector_instantiates():
     connector = BingXConnector()
     assert connector.client is not None
+
+
+def test_bingx_get_klines_returns_ten_candles():
+    connector = BingXConnector()
+    dummy = [[i, 1, 2, 0, 1, 0] for i in range(10)]
+    with patch.object(connector.client, "fetch_ohlcv", return_value=dummy):
+        batch = connector.get_klines("BTC/USDT", "1m")
+    assert len(batch.candles) == 10

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,16 @@
+from hermes_trading.candles import Candle, CandleBatch
 from hermes_trading.signals import PriceActionSignal
 
 
-def test_price_action_signal_stub_returns_false():
-    signal = PriceActionSignal(pattern="pin_bar")
-    assert signal.evaluate([1.0, 2.0, 3.0]) is False
+def test_price_action_signal_detects_patterns():
+    candles = [
+        Candle(0, 105, 106, 99, 100),  # bearish candle
+        Candle(1, 99, 108, 98, 107),  # bullish engulfing
+        Candle(2, 95, 97, 85, 96),  # pin bar
+    ]
+    candles.extend(Candle(i, 100, 101, 99, 100) for i in range(3, 10))
+    batch = CandleBatch(list(candles))
+    signal = PriceActionSignal()
+    results = signal.evaluate(batch)
+    assert any("bullish_engulfing" in r for r in results)
+    assert any("pin_bar" in r for r in results)


### PR DESCRIPTION
## Summary
- add Candle and CandleBatch models to represent OHLC data
- implement `get_klines` in Binance and BingX connectors
- analyze ten-candle batches for pin bar and bullish engulfing patterns
- add script to scan the last month's candles and report price action signals

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ab79fcdf1083268a070883599ff66e