### PR TITLE
Add liquidity level support and trade tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Trading bot framework core"
 requires-python = ">=3.10"
 dependencies = [
     "ccxt>=4.0.0",
+    "numpy",
+    "pandas",
 ]
 
 [build-system]

--- a/scan_month_signals.py
+++ b/scan_month_signals.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from typing import List
 
 from hermes_trading.candles import Candle, CandleBatch
 from hermes_trading.connectors import BinanceConnector
+from hermes_trading.liquidity import LiquidityLevels
 from hermes_trading.signals import PriceActionSignal
+from hermes_trading.trading import Trade, open_trade, update_trades
 
 
 def main() -> None:
@@ -19,21 +22,34 @@ def main() -> None:
     candles = [Candle(ts, o, h, l, c) for ts, o, h, l, c, *_ in ohlcv]
 
     signal = PriceActionSignal()
-    seen: set[tuple[int, str]] = set()
+    levels = LiquidityLevels()
+    levels.build(candles)
+    trades: List[Trade] = []
 
-    for i in range(0, len(candles) - 9):
-        batch = CandleBatch(candles[i : i + 10])
-        for res in signal.evaluate(batch):
-            name, idx = res.split("@")
-            candle = batch.candles[int(idx)]
-            key = (candle.timestamp, name)
-            if key in seen:
-                continue
-            seen.add(key)
-            ts = datetime.fromtimestamp(candle.timestamp / 1000, tz=timezone.utc)
-            print(
-                f"{name} at {ts.isoformat()} - O:{candle.open} H:{candle.high} L:{candle.low} C:{candle.close}"
+    for i in range(9, len(candles)):
+        current = candles[i]
+        update_trades(trades, current)
+
+        batch = CandleBatch(candles[i - 9 : i + 1])
+        active_levels = levels.active_levels(current.timestamp)
+        results = [r for r in signal.evaluate(batch, active_levels) if r.endswith("@9")]
+        for res in results:
+            name, _ = res.split("@")
+            touched = next(
+                lvl for lvl in active_levels if current.low <= lvl.price <= current.high
             )
+            trades.append(open_trade(current, name, touched))
+        levels.prune(current)
+
+    wins = sum(1 for t in trades if t.result == "take")
+    losses = sum(1 for t in trades if t.result == "stop")
+    print(f"Profitable trades: {wins}")
+    print(f"Losing trades: {losses}")
+    print("Signals:")
+    for t in trades:
+        ts = datetime.fromtimestamp(t.opened_at / 1000, tz=timezone.utc)
+        lvl_ts = datetime.fromtimestamp(t.level_start / 1000, tz=timezone.utc)
+        print(f"{t.pattern} at {ts.isoformat()} level {t.level_price} from {lvl_ts.isoformat()}")
 
 
 if __name__ == "__main__":

--- a/src/hermes_trading/__init__.py
+++ b/src/hermes_trading/__init__.py
@@ -1,5 +1,5 @@
 """Hermes Trading Bot core package."""
 
-from . import connectors, signals, candles
+from . import candles, connectors, liquidity, signals, trading
 
-__all__ = ["connectors", "signals", "candles"]
+__all__ = ["candles", "connectors", "liquidity", "signals", "trading"]

--- a/src/hermes_trading/liquidity.py
+++ b/src/hermes_trading/liquidity.py
@@ -1,0 +1,74 @@
+"""Utilities for detecting and managing liquidity levels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+from .candles import Candle
+
+
+@dataclass
+class Level:
+    """Represents a liquidity level derived from an extreme candle."""
+
+    price: float
+    type: str  # "high" or "low"
+    timestamp: int
+    active: bool = True
+
+
+class LiquidityLevels:
+    """Builds and maintains a list of liquidity levels."""
+
+    def __init__(self, window: int = 4) -> None:
+        self.window = window
+        self.levels: List[Level] = []
+
+    def build(self, candles: List[Candle]) -> None:
+        """Build initial levels from the provided candles."""
+        if not candles:
+            return
+        df = _candles_to_df(candles)
+        highs_idx, lows_idx = [], []
+        H, L = df["High"].values, df["Low"].values
+        for i in range(self.window, len(df) - self.window):
+            if H[i] == np.max(H[i - self.window : i + self.window + 1]):
+                highs_idx.append(i)
+            if L[i] == np.min(L[i - self.window : i + self.window + 1]):
+                lows_idx.append(i)
+        levels: List[Level] = []
+        for i in highs_idx:
+            ts = int(df.index[i].timestamp() * 1000)
+            levels.append(Level(price=float(H[i]), type="high", timestamp=ts))
+        for i in lows_idx:
+            ts = int(df.index[i].timestamp() * 1000)
+            levels.append(Level(price=float(L[i]), type="low", timestamp=ts))
+        levels.sort(key=lambda x: x.timestamp)
+        self.levels = levels
+
+    def active_levels(self, timestamp: int) -> List[Level]:
+        """Return all active levels that formed before given timestamp."""
+        return [l for l in self.levels if l.active and l.timestamp <= timestamp]
+
+    def prune(self, candle: Candle) -> None:
+        """Mark levels as inactive if the candle touches them."""
+        for lvl in self.levels:
+            if not lvl.active:
+                continue
+            if candle.low <= lvl.price <= candle.high:
+                lvl.active = False
+
+
+def _candles_to_df(candles: List[Candle]) -> pd.DataFrame:
+    data = {
+        "Open": [c.open for c in candles],
+        "High": [c.high for c in candles],
+        "Low": [c.low for c in candles],
+        "Close": [c.close for c in candles],
+    }
+    index = pd.to_datetime([c.timestamp for c in candles], unit="ms", utc=True)
+    return pd.DataFrame(data, index=index)

--- a/src/hermes_trading/signals/price_action.py
+++ b/src/hermes_trading/signals/price_action.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import List
 
 from ..candles import Candle, CandleBatch
+from ..liquidity import Level
 from .base import Signal
 
 
@@ -13,10 +14,17 @@ from .base import Signal
 class PriceActionSignal(Signal):
     """Detects price action patterns within a batch of candles."""
 
-    def evaluate(self, candles: CandleBatch) -> List[str]:  # type: ignore[override]
+    def evaluate(self, candles: CandleBatch, levels: List[Level]) -> List[str]:  # type: ignore[override]
+        """Return patterns that occur on provided liquidity levels."""
+
         signals: List[str] = []
         bars = candles.candles
         for i, bar in enumerate(bars):
+            if not any(
+                lvl.active and lvl.timestamp <= bar.timestamp and bar.low <= lvl.price <= bar.high
+                for lvl in levels
+            ):
+                continue
             if self._is_pin_bar(bar):
                 signals.append(f"pin_bar@{i}")
             if i > 0 and self._is_bullish_engulfing(bars[i - 1], bar):

--- a/src/hermes_trading/trading.py
+++ b/src/hermes_trading/trading.py
@@ -1,0 +1,49 @@
+"""Simple trade management for backtesting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .candles import Candle
+from .liquidity import Level
+
+
+@dataclass
+class Trade:
+    entry: float
+    stop: float
+    take: float
+    opened_at: int
+    pattern: str
+    level_price: float
+    level_start: int
+    closed_at: int | None = None
+    result: str | None = None  # "take" or "stop"
+
+
+def open_trade(candle: Candle, pattern: str, level: Level) -> Trade:
+    """Create a trade based on the closing candle."""
+    risk = candle.close - candle.low
+    return Trade(
+        entry=candle.close,
+        stop=candle.low,
+        take=candle.close + 2 * risk,
+        opened_at=candle.timestamp,
+        pattern=pattern,
+        level_price=level.price,
+        level_start=level.timestamp,
+    )
+
+
+def update_trades(trades: List[Trade], candle: Candle) -> None:
+    """Update open trades based on a new candle."""
+    for t in trades:
+        if t.result:
+            continue
+        if candle.low <= t.stop:
+            t.result = "stop"
+            t.closed_at = candle.timestamp
+        elif candle.high >= t.take:
+            t.result = "take"
+            t.closed_at = candle.timestamp

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,8 +1,9 @@
 from hermes_trading.candles import Candle, CandleBatch
+from hermes_trading.liquidity import Level
 from hermes_trading.signals import PriceActionSignal
 
 
-def test_price_action_signal_detects_patterns():
+def test_price_action_signal_detects_patterns_on_levels():
     candles = [
         Candle(0, 105, 106, 99, 100),  # bearish candle
         Candle(1, 99, 108, 98, 107),  # bullish engulfing
@@ -10,7 +11,24 @@ def test_price_action_signal_detects_patterns():
     ]
     candles.extend(Candle(i, 100, 101, 99, 100) for i in range(3, 10))
     batch = CandleBatch(list(candles))
+    levels = [
+        Level(price=98, type="low", timestamp=1),
+        Level(price=85, type="low", timestamp=2),
+    ]
     signal = PriceActionSignal()
-    results = signal.evaluate(batch)
+    results = signal.evaluate(batch, levels)
     assert any("bullish_engulfing" in r for r in results)
     assert any("pin_bar" in r for r in results)
+
+
+def test_price_action_signal_requires_level():
+    candles = [
+        Candle(0, 105, 106, 99, 100),
+        Candle(1, 99, 108, 98, 107),
+        Candle(2, 95, 97, 85, 96),
+    ]
+    candles.extend(Candle(i, 100, 101, 99, 100) for i in range(3, 10))
+    batch = CandleBatch(list(candles))
+    signal = PriceActionSignal()
+    results = signal.evaluate(batch, [])
+    assert results == []

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,0 +1,21 @@
+from hermes_trading.candles import Candle
+from hermes_trading.liquidity import Level
+from hermes_trading.trading import open_trade, update_trades
+
+
+def test_trade_hits_take():
+    c0 = Candle(0, 1.0, 1.5, 0.5, 1.2)
+    level = Level(price=0.5, type="low", timestamp=0)
+    trade = open_trade(c0, "pin_bar", level)
+    c1 = Candle(1, 1.2, trade.take + 0.1, trade.stop + 0.1, trade.take + 0.05)
+    update_trades([trade], c1)
+    assert trade.result == "take"
+
+
+def test_trade_hits_stop():
+    c0 = Candle(0, 1.0, 1.5, 0.5, 1.2)
+    level = Level(price=0.5, type="low", timestamp=0)
+    trade = open_trade(c0, "pin_bar", level)
+    c1 = Candle(1, 1.2, trade.take - 0.1, trade.stop - 0.1, trade.stop - 0.05)
+    update_trades([trade], c1)
+    assert trade.result == "stop"


### PR DESCRIPTION
## Summary
- detect liquidity levels and track their activity
- emit price action signals only when candles touch active liquidity levels
- add simple trade simulator with take/stop statistics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae193b54a483269c05ce77740c0581